### PR TITLE
Change download links to install instructions.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,4 @@ pygments: true
 current_version:  1.0
 repo:             https://github.com/sunpy/sunpy
 
-download_source:  https://github.com/sunpy/sunpy/archive/stable.zip
-download_dist:    https://github.com/sunpy/sunpy/archive/master.zip
-
-
+install_instructions: http://docs.sunpy.org/en/stable/guide/installation/

--- a/index.html
+++ b/index.html
@@ -13,8 +13,7 @@ base_url: "./"
 			<h1>SunPy</h1>
 			<p class="lead">The community-developed, free and open-source solar data analysis environment for Python.</p>
 			<p>
-			<a href="{{ site.download_source }}" class="btn btn-outline-inverse btn-lg">Download Release</a>
-			<a href="{{ site.download_dist }}" class="btn btn-outline-inverse btn-lg">Download Latest</a>
+			<a href="{{ site.install-instructions }}" class="btn btn-outline-inverse btn-lg">Install SunPy</a>
 			</p>
 		</div>
 	</div>


### PR DESCRIPTION
This follows from sunpy/sunpy#1181 and changes the download links to a link to the installation instructions.