### PR TITLE
Updated files to work with Jekyll 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source 'https://rubygems.org'
 gem 'github-pages'
+gem 'kramdown'
+gem 'rouge'

--- a/_config.yml
+++ b/_config.yml
@@ -10,14 +10,16 @@ timezone: "America/New_York"
 
 exclude:          [".editorconfig", ".gitignore", "bower.json", "composer.json", "CONTRIBUTING.md", "CNAME", "LICENSE", "Gruntfile.js", "package.json", "node_modules", "README.md", "less"]
 
-markdown: rdiscount
+markdown: kramdown
 permalink: pretty
-relative_permalinks: true
 
-highlighter: pygments
+highlighter: rouge
 
 # Custom vars
 current_version:  1.0
 repo:             https://github.com/sunpy/sunpy
 
 install_instructions: http://docs.sunpy.org/en/stable/guide/installation/
+
+gems: [jekyll-paginate]
+


### PR DESCRIPTION
This needed to change the markdown parser to kramdown and the syntax
highlighter to rouge.