### PR TITLE
Author names link to github under blog posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@ permalink: pretty
 
 authors:
    Cadair:
-      display_name: "Stuart Mumford"
+      display_name: Stuart Mumford
       github: "https://github.com/Cadair"
        
    dpshelio:

--- a/_config.yml
+++ b/_config.yml
@@ -16,16 +16,21 @@ permalink: pretty
 
 authors:
    Cadair:
-      display_name: Stuart Mumford
+      display_name: "Stuart Mumford"
       github: "https://github.com/Cadair"
        
    dpshelio:
-      display_name: David Pérez-Suárez
+      display_name: "David Pérez-Suárez"
       github: "https://github.com/dpshelio"
    
    wafels:
-      display_name: Jack Ireland
+      display_name: "Jack Ireland"
       github: "https://github.com/wafels"
+    
+   ehsteve:
+      display_name: "Steven Christe"
+      github: "https://github.com/ehsteve"
+   
   
 # more authors names to be added. Just for testing now
 

--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,24 @@ exclude:          [".editorconfig", ".gitignore", "bower.json", "composer.json",
 markdown: kramdown
 permalink: pretty
 
+
+authors:
+   Cadair:
+      display_name: "Stuart Mumford"
+      github: "https://github.com/Cadair"
+       
+   dpshelio:
+      display_name: David Pérez-Suárez
+      github: "https://github.com/dpshelio"
+   
+   wafels:
+      display_name: Jack Ireland
+      github: "https://github.com/wafels"
+  
+# more authors names to be added. Just for testing now
+
+
+
 highlighter: rouge
 
 # Custom vars

--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,7 @@
 name: "SunPy"
 description: "Python for Solar Physics"
 
-url: "http://sunpy.github.io/"
-#url: "http://localhost:4000/"
+url: "http://sunpy.org"
 
 paginate: 5
 paginate_path: "blog/page:num"
@@ -12,6 +11,8 @@ exclude:          [".editorconfig", ".gitignore", "bower.json", "composer.json",
 
 markdown: kramdown
 permalink: pretty
+
+highlighter: rouge
 
 
 authors:
@@ -31,12 +32,7 @@ authors:
       display_name: "Steven Christe"
       github: "https://github.com/ehsteve"
    
-  
-# more authors names to be added. Just for testing now
 
-
-
-highlighter: rouge
 
 # Custom vars
 current_version:  1.0

--- a/_posts/2012-11-27-sunpy-02.md
+++ b/_posts/2012-11-27-sunpy-02.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: SunPy 0.2
-author: Stuart Mumford
+author: Cadair
 ---
 It has been a busy year but a lot of code later SunPy version 0.2.0 has arrived!
 

--- a/_posts/2013-04-09-gsoc.md
+++ b/_posts/2013-04-09-gsoc.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Google Summer of Code
-author: Stuart Mumford
+author: Cadair
 ---
 SunPy is participating in the [Google Summer of Code 2013](http://http//www.google-melange.com/gsoc/homepage/google/gsoc2013) under the umbrella of the [Python Software Foundation](http://wiki.python.org/moin/SummerOfCode/2013).
 

--- a/_posts/2013-05-28-gsoc-community-bonding.md
+++ b/_posts/2013-05-28-gsoc-community-bonding.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: GSOC Community Bonding Period starting now!
-author: David Pérez-Suárez
+author: dpshelio
 ---
 From our last post you may remember that SunPy is participating in GSOC-2013 under the [PSF](http://wiki.python.org/moin/SummerOfCode/2013) (!= [Point Spread Function](http://en.wikipedia.org/wiki/Point_spread_function)). Yesterday, Google announced the accepted candidates for their summer of code.  If you look the [list](http://www.google-melange.com/gsoc/projects/list/google/gsoc2013) you will find between all these students that there are two whose projects is to work with SunPy.
 

--- a/_posts/2013-09-02-ESA-Summer-of-Code-in-Space.md
+++ b/_posts/2013-09-02-ESA-Summer-of-Code-in-Space.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: ESA Summer of Code
-author: Stuart Mumford
+author: Cadair
 ---
 I am happy to announce that for the third year running SunPy has got a summer student from ESA’s SOCIS program. This year the student is Tomas Meszaros.
 Tomas’ project this summer will be working on creating a new core data type for SunPy, the HyperMap. Which will be designed to hold ND data with at least one spatial dimension and any combination of other axes such as Wavelength, Temperature or Time. This data type will allow us to support data from instruments such as Hinode EIS and the newly launched IRIS satellite, as well as a multitude of high resolution ground based instruments.

--- a/_posts/2014-02-14-SunPy-0.4.md
+++ b/_posts/2014-02-14-SunPy-0.4.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Announcing SunPy 0.4
-author: Stuart Mumford
+author: Cadair
 ---
 The SunPy community is pleased to announce the release of SunPy 0.4.0.
 This release contains many new features, some of which are contributed by people 

--- a/_posts/2015-11-02-Monthly-Update.md
+++ b/_posts/2015-11-02-Monthly-Update.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: SunPy Update - November 2015
-author: Stuart Mumford
+author: Cadair
 ---
 
 Hello all,

--- a/_posts/2016-02-15-Monthly-Update.md
+++ b/_posts/2016-02-15-Monthly-Update.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: SunPy Update - February 2016
-author: Stuart Mumford
+author: Cadair
 
 ---
 

--- a/_posts/2016-03-07-march-update.md
+++ b/_posts/2016-03-07-march-update.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: SunPy Update - March 2016
-author: Stuart Mumford
+author: Cadair
 
 ---
 

--- a/_posts/2016-03-21-python-in-astronomy.md
+++ b/_posts/2016-03-21-python-in-astronomy.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: First impressions from SunPy at Python in Astronomy 2016
-author: Steven Christe
+author: ehsteve
 ---
 Steven Christe ([@ehsteve](https://github.com/ehsteve)) and Stuart Mumford ([@Cadair](https://github.com/ehsteve)) got to attend the (great) 
 [Python in Astronomy](http://python-in-astronomy.github.io/2016/) conference

--- a/_posts/2016-05-26-SunPy-07.md
+++ b/_posts/2016-05-26-SunPy-07.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: SunPy 0.7
-author: Stuart Mumford
+author: Cadair
 ---
 
 SunPy 0.7 has arrived! This release is a culmination of about 10 months of work from 27 different people. This release brings many [changes](https://github.com/sunpy/sunpy/blob/0.7/CHANGELOG.md), the highlights are:

--- a/_posts/2016-05-31-SPD2016.md
+++ b/_posts/2016-05-31-SPD2016.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: SPD 2016
-author: Steven Christe
+author: ehsteve
 ---
 
 You can find all of the material for the introductory 

--- a/blog/index.html
+++ b/blog/index.html
@@ -8,13 +8,15 @@ base_url: "../"
 {% for post in paginator.posts %}
   <h1><a id="{{ post.title }}" href="{{ post.url }}">{{ post.title }}</a></h1>
   <p class="author">
+    {% assign  auth = site.authors[post.author] %}
     Posted on <span class="date">{{ post.date | date: "%-d %B %Y" }}</span> 
-    by <span class="author">{{ post.author }}</span> 
+    by <a href = "{{auth.github}}"><span class="author">{{ auth.display_name }}</span></a>
   </p>
   <div class="content">
     {{ post.content }}
   </div>
 {% endfor %}
+
 
 <!-- Pagination links -->
 <div class="pagination">


### PR DESCRIPTION
Blog author names should link to their github profile.
This is done by creating a structure in the _config.yml file

`authors:
        name1:
            display_name : "sfdjvsb" 
             github: "github link"
`

I haven't done for author_names till now in order to test. 